### PR TITLE
Unit tests, fixes calculation of number size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:8.10
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ This module has been implemented by reading a few resources.
 
 - [Item Size in DdynamoDB from stack overflow](http://stackoverflow.com/questions/8988389/itemsize-in-dynamodb)
 - [Provision Throughput from the AWS DynamoDB docs](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html)
+- [Naming Rules and Data Types](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
+- [Item Sizes and Capacity Unit Consumption](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/CapacityUnitCalculations.html#ItemSizeCalculations.Reads)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/jmhummel/dyno-item-size/tree/master.svg?style=svg&circle-token=c3dcad6dd3bbd2347fcc8eaaacbdd4dcb1e030c9)](https://circleci.com/gh/jmhummel/dyno-item-size/tree/master)
+[![CircleCI](https://circleci.com/gh/mcwhittemore/dyno-item-size.svg?style=svg)](https://circleci.com/gh/mcwhittemore/dyno-item-size)
 
 # Dyno Item Size
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/jmhummel/dyno-item-size/tree/master.svg?style=svg&circle-token=c3dcad6dd3bbd2347fcc8eaaacbdd4dcb1e030c9)](https://circleci.com/gh/jmhummel/dyno-item-size/tree/master)
+
 # Dyno Item Size
 
 This is a simple utility to calculate the size of an item as [DynamoDB](https://aws.amazon.com/documentation/dynamodb/) would. The goal of this project is to be accurate within a byte so that you can make optimized requests to DynamoDB.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ var item = {
 };
 var size = dynoItemSize(item);
 console.log(size);
-// => 31
+// => 32
 ```
 
 ## API

--- a/index.js
+++ b/index.js
@@ -24,10 +24,24 @@ var sizeOfValue = module.exports.sizeOfValue = function(v) {
   // Leading and trailing zeroes are trimmed. The size of a number is approximately 
   // (length of attribute name) + (1 byte per two significant digits) + (1 byte).
   else if(typeof v === 'number') {
-    // Convert to binary, remove leading zeros, remove decimal, remove trailing zeros
-    var len = v.toString().replace(/^0\.0*|\.|0+$/g, '').length;
+    // Convert to string, remove decimal, remove trailing zeros, remove leading zeros
+    var n = v.toString();
+    n = n.replace(/e[+-]\d+$/, '');
+    n = n.replace(/^-/, '');
+    n = n.replace('.', '');
+    n = n.replace(/^0+/, '');
+    n = n.replace(/0+$/, '');
+    
+    var len = n.length;
     len = len > 38 ? 38 : len;
     s += Math.ceil(len/2) + 1;
+  }
+  // Binary
+  // A binary value must be encoded in base64 format before it can be sent to 
+  // DynamoDB, but the value's raw byte length is used for calculating size. 
+  // The size of a binary attribute is (length of attribute name) + (number of raw bytes).
+  else if (v instanceof Buffer) {
+    s += v.length;
   }
   // Boolean value
   // The size of a null attribute or a Boolean attribute is (length of attribute name) + (1 byte)
@@ -55,7 +69,7 @@ var sizeOfValue = module.exports.sizeOfValue = function(v) {
     }
   }
   // unknown type
-  else s += v.length;
+  else throw new Error("Unknown Type:", v);
   return s;  
 }
 

--- a/index.js
+++ b/index.js
@@ -24,13 +24,12 @@ var sizeOfValue = module.exports.sizeOfValue = function(v) {
   // Leading and trailing zeroes are trimmed. The size of a number is approximately 
   // (length of attribute name) + (1 byte per two significant digits) + (1 byte).
   else if(typeof v === 'number') {
-    // Convert to string, remove decimal, remove trailing zeros, remove leading zeros
-    var n = v.toString();
-    n = n.replace(/e[+-]\d+$/, '');
-    n = n.replace(/^-/, '');
-    n = n.replace('.', '');
-    n = n.replace(/^0+/, '');
-    n = n.replace(/0+$/, '');
+    var n = v.toString();           // Convert to string
+    n = n.replace(/e[+-]\d+$/, ''); // Remove exponent portion
+    n = n.replace(/^-/, '');        // Remove negative sign
+    n = n.replace('.', '');         // Remove decimal point
+    n = n.replace(/^0+/, '');       // Remove leading zeros
+    n = n.replace(/0+$/, '');       // Remove tailing zeros
     
     var len = n.length;
     len = len > 38 ? 38 : len;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var sizeOfValue = module.exports.sizeOfValue = function(v) {
   // (length of attribute name) + (1 byte per two significant digits) + (1 byte).
   else if(typeof v === 'number') {
     // Convert to binary, remove leading zeros, remove decimal, remove trailing zeros
-    var len = v.toString(2).replace(/^0\.0*|\.|0+$/g, '').length;
+    var len = v.toString().replace(/^0\.0*|\.|0+$/g, '').length;
     len = len > 38 ? 38 : len;
     s += Math.ceil(len/2) + 1;
   }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -3,7 +3,7 @@ var dynoItemSize = require('..');
 var items = {
   string: { content: 'string', size: 12 },
   number: { content: 27, size: 8 },
-  buffer: { content: new Buffer.from('hi', 'utf8'), size: 8 }
+  buffer: { content: Buffer.from('hi', 'utf8'), size: 8 }
 };
 
 describe('should report back item size', function() {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -68,8 +68,7 @@ describe('should report back capactiy cost', function() {
 });
 
 describe('should calculate value sizes', function() {
-  describe('strings', function() {
-    
+  describe('string', function() {
     it('empty string', function() {
       let string = ''
       let expectedSize = 0;
@@ -80,6 +79,52 @@ describe('should calculate value sizes', function() {
       let string = 'helloworld';
       let expectedSize = string.length;
       assert.equal(sizeOfValue(string), expectedSize);
+    });
+    
+    it('unicode string 1', function() {
+      // U+00A9 COPYRIGHT SIGN; see http://codepoints.net/U+00A9
+      let utf16String = '\u00A9';
+      let utf8EncodedString = '\xC2\xA9';
+      let expectedSize = utf8EncodedString.length;
+      assert.equal(sizeOfValue(utf16String), expectedSize);
+    });
+    
+    it('unicode string 2', function() {
+      // U+10001 LINEAR B SYLLABLE B038 E; see http://codepoints.net/U+10001
+      let utf16String = '\uD800\uDC01';
+      let utf8EncodedString = '\xF0\x90\x80\x81';
+      let expectedSize = utf8EncodedString.length;
+      assert.equal(sizeOfValue(utf16String), expectedSize);
+    });
+  });
+  
+  describe('number', function() {
+    it('11', function() {
+      let number = 11;
+      let expectedSize = 2;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('basic string', function() {
+      let string = 'helloworld';
+      let expectedSize = string.length;
+      assert.equal(sizeOfValue(string), expectedSize);
+    });
+    
+    it('unicode string 1', function() {
+      // U+00A9 COPYRIGHT SIGN; see http://codepoints.net/U+00A9
+      let utf16String = '\u00A9';
+      let utf8EncodedString = '\xC2\xA9';
+      let expectedSize = utf8EncodedString.length;
+      assert.equal(sizeOfValue(utf16String), expectedSize);
+    });
+    
+    it('unicode string 2', function() {
+      // U+10001 LINEAR B SYLLABLE B038 E; see http://codepoints.net/U+10001
+      let utf16String = '\uD800\uDC01';
+      let utf8EncodedString = '\xF0\x90\x80\x81';
+      let expectedSize = utf8EncodedString.length;
+      assert.equal(sizeOfValue(utf16String), expectedSize);
     });
   });
 });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,4 +1,6 @@
+var assert = require('assert');
 var dynoItemSize = require('..');
+var sizeOfValue = dynoItemSize.sizeOfValue;
 
 var items = {
   string: { content: 'string', size: 12 },
@@ -62,5 +64,22 @@ describe('should report back capactiy cost', function() {
     };
     var cap = dynoItemSize.read(item);
     if (cap !== 1) throw new Error(`Expected 1 but got ${cap}`);
+  });
+});
+
+describe('should calculate value sizes', function() {
+  describe('strings', function() {
+    
+    it('empty string', function() {
+      let string = ''
+      let expectedSize = 0;
+      assert.equal(sizeOfValue(string), expectedSize);
+    });
+    
+    it('basic string', function() {
+      let string = 'helloworld';
+      let expectedSize = string.length;
+      assert.equal(sizeOfValue(string), expectedSize);
+    });
   });
 });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,11 +1,9 @@
-var assert = require('assert');
 var dynoItemSize = require('..');
-var sizeOfValue = dynoItemSize.sizeOfValue;
 
 var items = {
   string: { content: 'string', size: 12 },
-  number: { content: 27, size: 10 },
-  buffer: { content: new Buffer('hi', 'utf8'), size: 8 }
+  number: { content: 27, size: 8 },
+  buffer: { content: new Buffer.from('hi', 'utf8'), size: 8 }
 };
 
 describe('should report back item size', function() {
@@ -64,67 +62,5 @@ describe('should report back capactiy cost', function() {
     };
     var cap = dynoItemSize.read(item);
     if (cap !== 1) throw new Error(`Expected 1 but got ${cap}`);
-  });
-});
-
-describe('should calculate value sizes', function() {
-  describe('string', function() {
-    it('empty string', function() {
-      let string = ''
-      let expectedSize = 0;
-      assert.equal(sizeOfValue(string), expectedSize);
-    });
-    
-    it('basic string', function() {
-      let string = 'helloworld';
-      let expectedSize = string.length;
-      assert.equal(sizeOfValue(string), expectedSize);
-    });
-    
-    it('unicode string 1', function() {
-      // U+00A9 COPYRIGHT SIGN; see http://codepoints.net/U+00A9
-      let utf16String = '\u00A9';
-      let utf8EncodedString = '\xC2\xA9';
-      let expectedSize = utf8EncodedString.length;
-      assert.equal(sizeOfValue(utf16String), expectedSize);
-    });
-    
-    it('unicode string 2', function() {
-      // U+10001 LINEAR B SYLLABLE B038 E; see http://codepoints.net/U+10001
-      let utf16String = '\uD800\uDC01';
-      let utf8EncodedString = '\xF0\x90\x80\x81';
-      let expectedSize = utf8EncodedString.length;
-      assert.equal(sizeOfValue(utf16String), expectedSize);
-    });
-  });
-  
-  describe('number', function() {
-    it('11', function() {
-      let number = 11;
-      let expectedSize = 2;
-      assert.equal(sizeOfValue(number), expectedSize);
-    });
-    
-    it('basic string', function() {
-      let string = 'helloworld';
-      let expectedSize = string.length;
-      assert.equal(sizeOfValue(string), expectedSize);
-    });
-    
-    it('unicode string 1', function() {
-      // U+00A9 COPYRIGHT SIGN; see http://codepoints.net/U+00A9
-      let utf16String = '\u00A9';
-      let utf8EncodedString = '\xC2\xA9';
-      let expectedSize = utf8EncodedString.length;
-      assert.equal(sizeOfValue(utf16String), expectedSize);
-    });
-    
-    it('unicode string 2', function() {
-      // U+10001 LINEAR B SYLLABLE B038 E; see http://codepoints.net/U+10001
-      let utf16String = '\uD800\uDC01';
-      let utf8EncodedString = '\xF0\x90\x80\x81';
-      let expectedSize = utf8EncodedString.length;
-      assert.equal(sizeOfValue(utf16String), expectedSize);
-    });
   });
 });

--- a/test/sizeOfValue.test.js
+++ b/test/sizeOfValue.test.js
@@ -1,0 +1,174 @@
+var assert = require('assert');
+var dynoItemSize = require('..');
+var sizeOfValue = dynoItemSize.sizeOfValue;
+
+describe('should calculate value sizes', function() {
+  describe('string', function() {
+    it('empty string', function() {
+      let string = ''
+      let expectedSize = 0;
+      assert.equal(sizeOfValue(string), expectedSize);
+    });
+    
+    it('basic string', function() {
+      let string = 'helloworld';
+      let expectedSize = string.length;
+      assert.equal(sizeOfValue(string), expectedSize);
+    });
+    
+    it('unicode string 1', function() {
+      // U+00A9 COPYRIGHT SIGN; see http://codepoints.net/U+00A9
+      let utf16String = '\u00A9';
+      let utf8EncodedString = '\xC2\xA9';
+      let expectedSize = utf8EncodedString.length;
+      assert.equal(sizeOfValue(utf16String), expectedSize);
+    });
+    
+    it('unicode string 2', function() {
+      // U+10001 LINEAR B SYLLABLE B038 E; see http://codepoints.net/U+10001
+      let utf16String = '\uD800\uDC01';
+      let utf8EncodedString = '\xF0\x90\x80\x81';
+      let expectedSize = utf8EncodedString.length;
+      assert.equal(sizeOfValue(utf16String), expectedSize);
+    });
+  });
+  
+  describe('number', function() {
+    it('0', function() {
+      let number = 0;
+      let expectedSize = 1;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('1', function() {
+      let number = 1;
+      let expectedSize = 2;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('0.10', function() {
+      let number = 1;
+      let expectedSize = 2;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('01', function() {
+      let number = 01;
+      let expectedSize = 2;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('10', function() {
+      let number = 10;
+      let expectedSize = 2;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('1000.000', function() {
+      let number = 1000.000;
+      let expectedSize = 2;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('1000.0001', function() {
+      let number = 1000.0001;
+      let expectedSize = 5;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('1.111E-130', function() {
+      let number = 1.111E-130;
+      let expectedSize = 3;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('9.999E125', function() {
+      let number = 9.999E125;
+      let expectedSize = 3;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('9.999999999999998', function() {
+      let number = 9.999999999999998;
+      let expectedSize = 9;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+    
+    it('-11', function() {
+      let number = -11;
+      let expectedSize = 2;
+      assert.equal(sizeOfValue(number), expectedSize);
+    });
+  });
+  
+  describe('binary / bytes / buffer', function() {
+    it('Empty buffer', function() {
+      let buffer = Buffer.alloc(0);
+      let expectedSize = 0;
+      assert.equal(sizeOfValue(buffer), expectedSize);
+    });
+    
+    it('Array', function() {
+      let arr = [1,2,3,4];
+      let buffer = Buffer.from(arr);
+      let expectedSize = arr.length;
+      assert.equal(sizeOfValue(buffer), expectedSize);
+    });
+    
+    it('Hex', function() {
+      let hex = "c4fe";
+      let buffer = Buffer.from(hex, "hex");
+      let expectedSize = 2;
+      assert.equal(sizeOfValue(buffer), expectedSize);
+    });
+  });
+  
+  describe('boolean', function() {
+    it('true', function() {
+      let boolean = true;
+      let expectedSize = 1;
+      assert.equal(sizeOfValue(boolean), expectedSize);
+    });
+    
+    it('false', function() {
+      let boolean = false;
+      let expectedSize = 1;
+      assert.equal(sizeOfValue(boolean), expectedSize);
+    });
+  });
+  
+  describe('null', function() {
+    it('null', function() {
+      let expectedSize = 1;
+      assert.equal(sizeOfValue(null), expectedSize);
+    });
+  });
+  
+  describe('list', function() {
+    it('empty list', function() {
+      let list = [];
+      let expectedSize = 3;
+      assert.equal(sizeOfValue(list), expectedSize);
+    });
+    
+    it('list of lists', function() {
+      let list = [ [], [], [], ];
+      let expectedSize = 12;
+      assert.equal(sizeOfValue(list), expectedSize);
+    });
+    
+    it('nested lists', function() {
+      let list = [ [ [ [] ] ] ];
+      let expectedSize = 12;
+      assert.equal(sizeOfValue(list), expectedSize);
+    });
+  });
+  
+  describe('map', function() {
+    it('empty map', function() {
+      let map = {};
+      let expectedSize = 3;
+      assert.equal(sizeOfValue(map), expectedSize);
+    });
+  });
+});


### PR DESCRIPTION
### Fixes number size calculation
[Naming Rules and Data Types:](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html)
> Numbers can be positive, negative, or zero. Numbers can have up to 38 digits precision. Exceeding this results in an exception.
>Positive range: 1E-130 to 9.9999999999999999999999999999999999999E+125
>Negative range: -9.9999999999999999999999999999999999999E+125 to -1E-130

Looking at this page in the documentation, I realized my previous implementation was incorrect, and 1 byte = 2 decimal digits. Which makes more sense, since "99" takes 7 bits to store. The other 1 byte needed holds the exponent.

- Adds multiple unit tests for each value type
- Updates CircleCI build node version to 8.10 (LTS)
- Adds .gitignore
- Added a CircleCI badge to the README, you'll likely want to change that in your fork to point to your CircleCI instead